### PR TITLE
[FEAT] 반응형 디자인 적용

### DIFF
--- a/src/components/KanbanBoard/DevEnvironmentForm.tsx
+++ b/src/components/KanbanBoard/DevEnvironmentForm.tsx
@@ -6,9 +6,6 @@ import { useRecoilState } from 'recoil';
 import { devEnvironmentAtom } from '@/atoms/devEnvironmentAtom';
 import { theme, ThemeType } from '@/styles/theme';
 
-import HoverIcon from '../common/HoverIcon';
-import CheckIcon from '../icons/CheckIcon';
-
 export default function DevEnvironmentForm({ ...props }: React.ComponentProps<'form'>) {
   const [devState, setDevState] = useRecoilState(devEnvironmentAtom);
   const [framework, setFramework] = useState<string | undefined>(devState.framework);
@@ -48,7 +45,7 @@ export default function DevEnvironmentForm({ ...props }: React.ComponentProps<'f
         onChange={(e) => handleInputChange(e, setLanguage)}
       />
       <button aria-label="dev-submit-btn" type="submit" className="dev-submit-btn">
-        <HoverIcon icon={<CheckIcon />} />
+        <span>등록</span>
       </button>
     </form>
   );
@@ -68,6 +65,8 @@ const devEnvironmentFormStyle = (theme: ThemeType) => css`
   }
 
   button {
+    margin-left: 5px;
+    padding-top: 3px;
     :hover {
       color: ${theme.colors.green};
     }

--- a/src/components/KanbanBoard/IssueInfo.tsx
+++ b/src/components/KanbanBoard/IssueInfo.tsx
@@ -20,18 +20,18 @@ const issueInfoStyle = (theme: ThemeType) => css`
   width: 100%;
   display: flex;
   align-items: center;
-  flex-direction: column;
-  gap: 10px;
-  padding: 10px 20px;
+  gap: 20px;
+  padding: 20px;
 
   .issue-modal-title {
     font-size: 1.2rem;
     font-weight: 700;
   }
 
-  @media (min-width: ${theme.screens.md}px) {
-    flex-direction: row;
-    gap: 20px;
+  @media (max-width: ${theme.screens.md}px) {
+    flex-direction: column;
+    gap: 10px;
+    padding: 10px;
     padding-bottom: 5px;
   }
 `;

--- a/src/components/KanbanBoard/IssueInfo.tsx
+++ b/src/components/KanbanBoard/IssueInfo.tsx
@@ -1,5 +1,7 @@
 import { css } from '@emotion/react';
 
+import { theme, ThemeType } from '@/styles/theme';
+
 import DevEnvironmentForm from './DevEnvironmentForm';
 
 type IssueInfoProps = {
@@ -8,20 +10,28 @@ type IssueInfoProps = {
 
 export default function IssueInfo({ issueTitle }: IssueInfoProps) {
   return (
-    <section css={issueInfoStyle}>
+    <section css={issueInfoStyle(theme)}>
       <h2 className="issue-modal-title">{issueTitle}</h2>
       <DevEnvironmentForm />
     </section>
   );
 }
-const issueInfoStyle = css`
+const issueInfoStyle = (theme: ThemeType) => css`
+  width: 100%;
   display: flex;
   align-items: center;
-  gap: 20px;
-  padding: 10px 20px 5px 20px;
+  flex-direction: column;
+  gap: 10px;
+  padding: 10px 20px;
 
   .issue-modal-title {
     font-size: 1.2rem;
     font-weight: 700;
+  }
+
+  @media (min-width: ${theme.screens.md}px) {
+    flex-direction: row;
+    gap: 20px;
+    padding-bottom: 5px;
   }
 `;

--- a/src/components/Modal/BaseModal.tsx
+++ b/src/components/Modal/BaseModal.tsx
@@ -25,7 +25,7 @@ export default function BaseModal({ type, children, onClose }: BaseModalProps) {
   }, []);
 
   return (
-    <div css={baseModalStyle}>
+    <div role="dialog" css={baseModalStyle}>
       <div className="modal-overlay" onClick={handleModalClose} />
       <div className="modal-container">
         <button aria-label="modal-close-btn" className="modal-close-btn" onClick={handleModalClose}>

--- a/src/components/Modal/GPTInfoModal.tsx
+++ b/src/components/Modal/GPTInfoModal.tsx
@@ -9,7 +9,7 @@ import APITestSection from '../gpt/info/APITestSection';
 export default function GPTInfoModal() {
   return (
     <div css={containerStyle(theme)}>
-      <section css={infoSectionStyle}>
+      <section className="gpt-info-section">
         <APISetupSection />
         <APITestSection />
         <APIInfoSection />
@@ -33,19 +33,42 @@ const containerStyle = (theme: ThemeType) => css`
     font-weight: 700;
     color: ${theme.colors.beige};
   }
-`;
-
-const infoSectionStyle = css`
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-  gap: 40px;
-  padding: 10px 0;
-  margin: auto;
 
   div {
     display: flex;
     flex-direction: column;
     gap: 10px;
+  }
+
+  .gpt-info-section {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: 40px;
+    padding: 10px 0;
+    margin: auto;
+  }
+
+  .gpt-info-title {
+    align-items: center;
+    flex-direction: row;
+  }
+
+  @media (max-width: ${theme.screens.sm}px) {
+    width: calc(100vw - 40px);
+    padding: 24px 18px;
+
+    .gpt-info-section {
+      gap: 25px;
+    }
+
+    .gpt-info-title {
+      flex-direction: column;
+    }
+
+    div {
+      gap: 2px;
+      padding-bottom: 8px;
+    }
   }
 `;

--- a/src/components/Modal/GPTInfoModal.tsx
+++ b/src/components/Modal/GPTInfoModal.tsx
@@ -19,7 +19,8 @@ export default function GPTInfoModal() {
 }
 
 const containerStyle = (theme: ThemeType) => css`
-  width: fit-content;
+  width: calc(100vw - 80px);
+  max-width: 625px;
   display: flex;
   background: ${theme.colors.white};
   padding: 24px 30px;
@@ -35,7 +36,7 @@ const containerStyle = (theme: ThemeType) => css`
 `;
 
 const infoSectionStyle = css`
-  width: fit-content;
+  width: 100%;
   display: flex;
   flex-direction: column;
   gap: 40px;

--- a/src/components/Modal/IssueModal.tsx
+++ b/src/components/Modal/IssueModal.tsx
@@ -4,6 +4,7 @@ import { useSearchParams } from 'react-router-dom';
 import { params } from '@/constants/params';
 import { useIssue } from '@/hooks/useIssue';
 import { useModal } from '@/hooks/useModal';
+import { theme, ThemeType } from '@/styles/theme';
 import { IssueStateType } from '@/types/issue';
 import { ModalType } from '@/types/modal';
 
@@ -27,16 +28,16 @@ export default function IssueModal() {
   if (!issueState) return null;
 
   return (
-    <div css={issueModalStyle}>
+    <div css={issueModalStyle(theme)}>
       <IssueInfo issueTitle={issueState.title} />
-      <div className="requirement-section">
+      <section className="requirement-section">
         <RequirementSection selectedIssueId={selectedIssueId} />
-      </div>
+      </section>
     </div>
   );
 }
 
-const issueModalStyle = css`
+const issueModalStyle = (theme: ThemeType) => css`
   width: calc(100vw - 80px);
   height: calc(100vh - 112px);
   background: #fff;
@@ -47,5 +48,9 @@ const issueModalStyle = css`
     padding: 0px 20px 0 20px;
     height: calc(100% - 70px);
     overflow: auto;
+  }
+
+  @media (max-width: ${theme.screens.sm}px) {
+    width: calc(100vw - 40px);
   }
 `;

--- a/src/components/Requirement/RequirementList.tsx
+++ b/src/components/Requirement/RequirementList.tsx
@@ -33,5 +33,5 @@ const requirementListStyle = css`
   flex: 1;
   gap: 10px;
   overflow: auto;
-  padding-top: 15px;
+  padding-bottom: 10px;
 `;

--- a/src/components/Requirement/RequirementSection.tsx
+++ b/src/components/Requirement/RequirementSection.tsx
@@ -17,6 +17,7 @@ type RequirementSectionProps = {
 
 export default function RequirementSection({ selectedIssueId }: RequirementSectionProps) {
   const { width } = useResize();
+  const panelDirection = width > theme.screens.md ? 'horizontal' : 'vertical';
 
   const [selectedRequireId, setSelectedRequireId] = useState<string | undefined>(undefined);
   const [selectedRequire, setSelectedRequire] = useState<RequirementStateType | undefined>(
@@ -37,7 +38,7 @@ export default function RequirementSection({ selectedIssueId }: RequirementSecti
 
   return (
     <section css={requirementSectionStyle}>
-      <PanelGroup direction={width > theme.screens.md ? 'horizontal' : 'vertical'}>
+      <PanelGroup direction={panelDirection}>
         <Panel>
           <RequirementList
             issueId={selectedIssueId}
@@ -45,7 +46,7 @@ export default function RequirementSection({ selectedIssueId }: RequirementSecti
             onSelectId={handleSelectId}
           />
         </Panel>
-        {width > theme.screens.md && <ResizeHandle />}
+        <ResizeHandle direction={panelDirection} />
         <Panel>
           <GPTPrompt requirement={selectedRequire} />
         </Panel>

--- a/src/components/Requirement/RequirementSection.tsx
+++ b/src/components/Requirement/RequirementSection.tsx
@@ -3,6 +3,8 @@ import { useEffect, useState } from 'react';
 import { Panel, PanelGroup } from 'react-resizable-panels';
 
 import { useRequirement } from '@/hooks/useRequirement';
+import useResize from '@/hooks/useResize';
+import { theme } from '@/styles/theme';
 import { RequirementStateType } from '@/types/requirement';
 
 import ResizeHandle from '../common/ResizeHandle';
@@ -14,6 +16,8 @@ type RequirementSectionProps = {
 };
 
 export default function RequirementSection({ selectedIssueId }: RequirementSectionProps) {
+  const { width } = useResize();
+
   const [selectedRequireId, setSelectedRequireId] = useState<string | undefined>(undefined);
   const [selectedRequire, setSelectedRequire] = useState<RequirementStateType | undefined>(
     undefined,
@@ -33,7 +37,7 @@ export default function RequirementSection({ selectedIssueId }: RequirementSecti
 
   return (
     <section css={requirementSectionStyle}>
-      <PanelGroup direction="horizontal">
+      <PanelGroup direction={width > theme.screens.md ? 'horizontal' : 'vertical'}>
         <Panel>
           <RequirementList
             issueId={selectedIssueId}
@@ -41,7 +45,7 @@ export default function RequirementSection({ selectedIssueId }: RequirementSecti
             onSelectId={handleSelectId}
           />
         </Panel>
-        <ResizeHandle />
+        {width > theme.screens.md && <ResizeHandle />}
         <Panel>
           <GPTPrompt requirement={selectedRequire} />
         </Panel>

--- a/src/components/common/ResizeHandle.tsx
+++ b/src/components/common/ResizeHandle.tsx
@@ -5,27 +5,33 @@ import { theme, ThemeType } from '@/styles/theme';
 
 import ResizeIcon from '../icons/ResizeIcon';
 
-export default function ResizeHandle() {
+export type DirectionType = 'horizontal' | 'vertical';
+
+type ResizeHandleProps = {
+  direction: DirectionType;
+};
+
+export default function ResizeHandle({ direction }: ResizeHandleProps) {
   return (
-    <PanelResizeHandle css={resizeHandleStyle(theme)}>
+    <PanelResizeHandle css={resizeHandleStyle(theme, direction)}>
       <div className="resize-line">
         <div className="resize-icon">
-          <ResizeIcon />
+          <ResizeIcon direction={direction} />
         </div>
       </div>
     </PanelResizeHandle>
   );
 }
 
-const resizeHandleStyle = (theme: ThemeType) => css`
+const resizeHandleStyle = (theme: ThemeType, direction: DirectionType) => css`
   position: relative;
-  width: 2px;
-  height: 100%;
-  padding: 0px 10px;
+  width: ${direction === 'horizontal' ? '2px' : '100%'};
+  height: ${direction === 'horizontal' ? '100%' : '2px'};
+  padding: ${direction === 'horizontal' ? '0 10px' : '10px 0'};
 
   .resize-line {
-    width: 2px;
-    height: 100%;
+    width: inherit;
+    height: inherit;
     transform: translateX(-1px);
     background: ${theme.colors.lightGray};
   }

--- a/src/components/gpt/GptPrompt.tsx
+++ b/src/components/gpt/GptPrompt.tsx
@@ -31,5 +31,6 @@ const gptPromptStyle = css`
   flex-direction: column;
   flex-shrink: 0;
   overflow: auto;
-  padding: 15px 0px 20px 10px;
+  padding: 10px;
+  padding-right: 0;
 `;

--- a/src/components/gpt/info/APIInfoSection.tsx
+++ b/src/components/gpt/info/APIInfoSection.tsx
@@ -1,5 +1,3 @@
-import { css } from '@emotion/react';
-
 import RoundedBtn from '@/components/common/RoundedBtn';
 
 export default function APIInfoSection() {
@@ -8,8 +6,8 @@ export default function APIInfoSection() {
   };
 
   return (
-    <div css={apiInfoSectionStyle}>
-      <div className="check-api-section">
+    <div>
+      <div className="gpt-info-title info">
         <h2>API 요청이 되지 않는다면?</h2>
         <RoundedBtn onClick={handleOpenUsagePage}>확인해보기</RoundedBtn>
       </div>
@@ -18,10 +16,3 @@ export default function APIInfoSection() {
     </div>
   );
 }
-
-const apiInfoSectionStyle = css`
-  .check-api-section {
-    flex-direction: row;
-    align-items: center;
-  }
-`;

--- a/src/components/gpt/info/APIKeyForm.tsx
+++ b/src/components/gpt/info/APIKeyForm.tsx
@@ -69,7 +69,7 @@ const formStyle = (theme: ThemeType) => css`
   }
 
   input {
-    width: 380px;
+    width: 100%;
     border-bottom: 1px solid ${theme.colors.primary};
   }
 

--- a/src/components/gpt/info/APISetupSection.tsx
+++ b/src/components/gpt/info/APISetupSection.tsx
@@ -1,5 +1,3 @@
-import { css } from '@emotion/react';
-
 import RoundedBtn from '@/components/common/RoundedBtn';
 
 import APIKeyForm from './APIKeyForm';
@@ -10,8 +8,8 @@ export default function APISetupSection() {
   };
 
   return (
-    <div css={apiSetupSectionStyle}>
-      <div className="setup-section">
+    <div>
+      <div className="gpt-info-title api-key">
         <h2>GPT API 연동</h2>
         <RoundedBtn onClick={handleOpenApiPage}>API Key 발급 받기</RoundedBtn>
       </div>
@@ -20,10 +18,3 @@ export default function APISetupSection() {
     </div>
   );
 }
-
-const apiSetupSectionStyle = css`
-  .setup-section {
-    flex-direction: row;
-    align-items: center;
-  }
-`;

--- a/src/components/gpt/info/APITestSection.tsx
+++ b/src/components/gpt/info/APITestSection.tsx
@@ -1,4 +1,3 @@
-import { css } from '@emotion/react';
 import { Comment } from 'react-loader-spinner';
 import { useMutation } from 'react-query';
 import { toast } from 'react-toastify';
@@ -30,8 +29,8 @@ export default function APITestSection() {
   };
 
   return (
-    <div css={apiTestSectionStyle}>
-      <div className="test-section">
+    <div>
+      <div className="gpt-info-title test">
         <h2>API 연동 테스트</h2>
         <RoundedBtn onClick={postApiTest}>
           {isLoading ? (
@@ -54,10 +53,3 @@ export default function APITestSection() {
     </div>
   );
 }
-
-const apiTestSectionStyle = css`
-  .test-section {
-    flex-direction: row;
-    align-items: center;
-  }
-`;

--- a/src/components/icons/ResizeIcon.tsx
+++ b/src/components/icons/ResizeIcon.tsx
@@ -1,9 +1,17 @@
 import { BsArrowsExpand } from 'react-icons/bs';
 
+import { DirectionType } from '../common/ResizeHandle';
+
 type ResizeIconProps = {
   size?: number;
+  direction: DirectionType;
 };
 
-export default function ResizeIcon({ size }: ResizeIconProps) {
-  return <BsArrowsExpand style={{ strokeWidth: '1' }} size={size} />;
+export default function ResizeIcon({ size, direction }: ResizeIconProps) {
+  return (
+    <BsArrowsExpand
+      style={{ strokeWidth: '1', rotate: direction === 'horizontal' ? '0deg' : '90deg' }}
+      size={size}
+    />
+  );
 }

--- a/src/hooks/useResize.ts
+++ b/src/hooks/useResize.ts
@@ -1,0 +1,25 @@
+import { useEffect, useState } from 'react';
+
+export default function useResize() {
+  const [windowSize, setWindowSize] = useState<{ width: number; height: number }>({
+    width: window.innerWidth,
+    height: window.innerHeight,
+  });
+
+  const handleResize = () => {
+    setWindowSize({
+      width: window.innerWidth,
+      height: window.innerHeight,
+    });
+  };
+
+  useEffect(() => {
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, []);
+
+  return windowSize;
+}

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -23,15 +23,15 @@ const palette = {
 };
 
 const screens = {
-  sm: '640px',
-  md: '768px',
-  lg: '1024px',
-  xl: '1280px',
+  sm: 425,
+  md: 768,
+  lg: 1024,
+  xl: 1280,
 };
 
 export type ThemeType = {
   colors: Record<string, string>;
-  screens: Record<string, string>;
+  screens: Record<string, number>;
 };
 
 export const theme: ThemeType = {

--- a/src/utils/textarea.ts
+++ b/src/utils/textarea.ts
@@ -15,7 +15,7 @@ export function autoResizeTextarea(ref: ForwardedRef<HTMLTextAreaElement>) {
     const textarea = ref.current;
     if (textarea !== null) {
       setTimeout(() => {
-        textarea.style.height = 'auto';
+        textarea.style.height = '0';
         textarea.style.height = `${textarea.scrollHeight}px`;
       }, 0);
     }


### PR DESCRIPTION
## 🌱 만들고자 하는 기능

- KanbanGPT 레이아웃을 모바일, 타블렛 크기에 대응할 수 있도록 변경합니다.


## 🌱 구현 내용

- [x] 반응형 크기(모바일, 타블렛, 데스크탑)를 theme에 정의합니다. 
- [x] 모달 내의 컴포넌트를 타블렛 사이즈 기준으로 수직, 수평 정렬을 변경합니다.
- [x] 방향에 따라서 Resize Handle의 크기와 아이콘의 각도를 변경합니다.
- [x] resize 시에 textarea의 높이가 적절히 변경되지 않는 오류를 수정했습니다.

## ✅ check list

- 이슈 내용을 전부 적용했나요?
- 산정한 작업 기간 내에 개발했나요?
