### PR TITLE
[FEAT] 모바일 노치, 인디케이터 영역 대응

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>KanbanGPT</title>
     <meta
       name="description"

--- a/src/components/KanbanBoard/IssueInput.tsx
+++ b/src/components/KanbanBoard/IssueInput.tsx
@@ -58,6 +58,7 @@ export default function IssueInput({ issue, autoFocus, onBlur, onCreateIssue }: 
 const issueInputStyle = (theme: ThemeType) => css`
   width: 100%;
   overflow: hidden;
+  padding-top: 2px;
 
   .issue-input {
     width: 100%;

--- a/src/components/KanbanBoard/IssueTitle.tsx
+++ b/src/components/KanbanBoard/IssueTitle.tsx
@@ -51,7 +51,7 @@ const issueTitleStyle = css`
   display: flex;
   justify-content: space-between;
   align-items: start;
-  padding-bottom: 12px;
+  padding-bottom: 10px;
   gap: 6px;
   min-height: 38px;
 `;

--- a/src/components/common/Navbar.tsx
+++ b/src/components/common/Navbar.tsx
@@ -66,7 +66,7 @@ const navBarStyle = (isNavOpen: boolean) => css`
   height: 100vh;
   position: absolute;
   top: 0;
-  left: 0;
+  left: env(safe-area-inset-left);
   z-index: 10;
   pointer-events: ${isNavOpen ? 'auto' : 'none'};
 
@@ -85,7 +85,7 @@ const navStyle = (isNavOpen: boolean, theme: ThemeType) => css`
   height: 100%;
   position: fixed;
   top: 0px;
-  left: 0;
+  left: env(safe-area-inset-left);
   transform: ${isNavOpen ? '0' : 'translatex(-100%)'};
   transition: transform 0.3s ease-in-out;
   display: flex;

--- a/src/components/gpt/GptPrompt.tsx
+++ b/src/components/gpt/GptPrompt.tsx
@@ -32,5 +32,4 @@ const gptPromptStyle = css`
   flex-shrink: 0;
   overflow: auto;
   padding: 10px;
-  padding-right: 0;
 `;

--- a/src/pages/CodeArchive.tsx
+++ b/src/pages/CodeArchive.tsx
@@ -13,8 +13,6 @@ export default function CodeArchive() {
 }
 
 const codeArchiveStyle = (theme: ThemeType) => css`
-  width: 100vw;
-  height: calc(100vh - 56px);
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -13,8 +13,6 @@ export default function Main() {
 }
 
 const mainPageStyle = (theme: ThemeType) => css`
-  width: 100vw;
-  height: calc(100vh - 56px);
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/src/styles/reset.ts
+++ b/src/styles/reset.ts
@@ -10,17 +10,29 @@ export const reset = css`
     font-weight: 400;
     word-break: keep-all;
   }
+
   body {
     width: 100%;
+    min-height: 100vh;
+    min-height: calc(100vh - env(safe-area-inset-top) - env(safe-area-inset-bottom));
+
+    padding: constant(safe-area-inset-top) constant(safe-area-inset-right)
+      constant(safe-area-inset-bottom) constant(safe-area-inset-left);
+
+    padding: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom)
+      env(safe-area-inset-left);
   }
+
   ol,
   ul {
     list-style: none;
   }
+
   button {
     background: none;
     cursor: pointer;
   }
+
   input,
   textarea {
     outline: none;


### PR DESCRIPTION
## 🌱 만들고자 하는 기능

- 모바일 환경에서 노치 영역, 인디케이터 영역으로 인해 너비 또는 높이가 잘리는 문제가 있습니다.
- css의 safe-area를 활용하여 노치, 인디케이터 영역 안에서 컨텐츠를 그리도록 합니다.

## 🌱 구현 내용

- [x] body의 100vh에서 safe-area-inset-top과 safe-area-inset-bottom 뺀 값을 min-height로 설정합니다.
- [x] safe-area-inset의 상하좌우 값을 body의 padding으로 설정합니다.
- [x] iOS 11이하 버전에서도 대응할 수 있게 constant를 사용하여 safe-area-inset을 설정합니다.


## ✅ check list

- 이슈 내용을 전부 적용했나요?
- 산정한 작업 기간 내에 개발했나요?
