### PR TITLE
[FEAT][FIX] 칸반보드 스크롤 snap 적용, safari clipboard 복사 에러 수정

### DIFF
--- a/src/api/axiosInstance.tsx
+++ b/src/api/axiosInstance.tsx
@@ -14,16 +14,17 @@ const onResponse = (response: AxiosResponse): AxiosResponse => {
 
 const onError = (error: AxiosError) => {
   const response = error.response as AxiosResponse;
-  switch (response.status) {
-    case 401:
+
+  if (response) {
+    if (response.status === 401) {
       toast.error(<ConnectToGptModal />, { autoClose: false });
-      break;
-    default:
-      if (response.data && response.data.error) {
-        toast.error(response.data.error);
-      }
-      break;
+    } else if (response.data?.error) {
+      toast.error(response.data.error);
+    }
+  } else {
+    toast.error('API 호출에 실패했습니다. 잠시 후 다시 시도해 주세요.');
   }
+
   return Promise.reject(error);
 };
 

--- a/src/components/KanbanBoard/KanbanBoard.tsx
+++ b/src/components/KanbanBoard/KanbanBoard.tsx
@@ -60,4 +60,5 @@ const kanbanBoardListStyle = css`
   gap: 16px;
   display: flex;
   overflow: auto;
+  scroll-snap-type: x mandatory;
 `;

--- a/src/components/KanbanBoard/KanbanCard.tsx
+++ b/src/components/KanbanBoard/KanbanCard.tsx
@@ -39,5 +39,6 @@ const kanbanLayoutStyle = css`
     padding-bottom: 15px;
     border-radius: 8px;
     box-shadow: rgba(99, 99, 99, 0.2) 0px 2px 8px 0px;
+    scroll-snap-align: center;
   }
 `;

--- a/src/components/Requirement/RequirementControlBtn.tsx
+++ b/src/components/Requirement/RequirementControlBtn.tsx
@@ -10,9 +10,9 @@ import { theme, ThemeType } from '@/styles/theme';
 import { RequirementStateType } from '@/types/requirement';
 import { copyText, generateSearchPrompt } from '@/utils/gpt';
 
+import DeleteHoverBtn from '../common/DeleteHoverBtn';
 import HoverIcon from '../common/HoverIcon';
 import GPTGenerateCodeBtn from '../gpt/GPTGenerateCodeBtn';
-import DeleteIcon from '../icons/DeleteIcon';
 import SearchIcon from '../icons/SearchIcon';
 import DeleteConfirmation from '../Toast/DeleteConfirmation';
 
@@ -66,11 +66,11 @@ export default function RequirementControlBtn({
         icon={<SearchIcon size={18} />}
         onClick={handleSearch}
       />
-      <HoverIcon
+      <DeleteHoverBtn
         aria-label="requirement-delete-btn"
         className="requirement-delete-btn"
-        icon={<DeleteIcon size={18} />}
         onClick={handleDelete}
+        iconSize={18}
       />
     </div>
   );
@@ -87,9 +87,7 @@ const requirementItemBtnStyle = (theme: ThemeType) => css`
   }
 
   .requirement-delete-btn {
-    opacity: 0.2;
-    :hover {
-      opacity: 0.6;
-    }
+    width: 28px;
+    height: 28px;
   }
 `;

--- a/src/components/common/DeleteHoverBtn.tsx
+++ b/src/components/common/DeleteHoverBtn.tsx
@@ -5,18 +5,21 @@ import { theme, ThemeType } from '@/styles/theme';
 import DeleteIcon from '../icons/DeleteIcon';
 import HoverIcon from './HoverIcon';
 
-export default function DeleteHoverBtn({ ...props }: React.ComponentProps<'button'>) {
+interface DeleteHoverBtnProps extends React.ComponentProps<'button'> {
+  iconSize?: number;
+}
+
+export default function DeleteHoverBtn({ iconSize, ...props }: DeleteHoverBtnProps) {
   return (
     <button aria-label="delete-btn" css={deleteHoverBtnStyle(theme)} {...props}>
-      <HoverIcon icon={<DeleteIcon />} />
+      <HoverIcon icon={<DeleteIcon size={iconSize} />} />
     </button>
   );
 }
 const deleteHoverBtnStyle = (theme: ThemeType) => css`
   display: flex;
   align-items: center;
-  padding-left: 5px;
-  opacity: 0;
+  opacity: 0.2;
   color: ${theme.colors.red};
 
   :hover {

--- a/src/types/gpt.ts
+++ b/src/types/gpt.ts
@@ -14,3 +14,9 @@ export type copyTextProps = {
   toastMessage?: string;
   isRequirement?: boolean;
 };
+
+export type handleTextCopyProps = {
+  callback: () => void;
+  toastMessage?: string;
+  isRequirement?: boolean;
+};

--- a/src/utils/gpt.ts
+++ b/src/utils/gpt.ts
@@ -1,6 +1,6 @@
 import { toast } from 'react-toastify';
 
-import { copyTextProps, generateSearchPromptProps } from '@/types/gpt';
+import { copyTextProps, generateSearchPromptProps, handleTextCopyProps } from '@/types/gpt';
 
 export const generateSearchPrompt = ({ title, framework, language }: generateSearchPromptProps) => {
   let sentence = '';
@@ -15,16 +15,41 @@ export const generateSearchPrompt = ({ title, framework, language }: generateSea
   return sentence;
 };
 
-export const copyText = async ({ text, toastMessage, isRequirement }: copyTextProps) => {
+const handleTextCopy = ({ callback, toastMessage, isRequirement }: handleTextCopyProps) => {
   try {
-    await navigator.clipboard.writeText(text);
+    callback();
+
     if (toastMessage) toast.success(toastMessage);
+
     if (isRequirement) {
-      setTimeout(() => {
-        window.open('https://chat.openai.com', '_blank');
-      }, 1200);
+      setTimeout(function () {
+        window.open('https://chat.openai.com');
+      }, 800);
     }
-  } catch (e) {
+  } catch (error) {
     toast.error('복사에 실패했어요. 다시 시도해 주세요.');
+  }
+};
+
+export const copyText = async ({ text, toastMessage, isRequirement }: copyTextProps) => {
+  if (navigator.clipboard) {
+    handleTextCopy({
+      callback: async () => await navigator.clipboard.writeText(text),
+      toastMessage,
+      isRequirement,
+    });
+  } else {
+    const textarea = document.createElement('textarea');
+    textarea.value = text;
+    document.body.appendChild(textarea);
+    textarea.select();
+
+    handleTextCopy({
+      callback: () => document.execCommand('copy'),
+      toastMessage,
+      isRequirement,
+    });
+
+    document.body.removeChild(textarea);
   }
 };


### PR DESCRIPTION
## 🌱 만들고자 하는 기능

- 칸반보드의 x 스크롤에 snap을 적용하여 스크롤 사용성을 높입니다.
- safari에서 발생하는 navigator.clipboard로 복사가 되지 않는 문제를 대응했습니다.
- axios 에러 처리 부분 코드를 가독성있게 수정하였습니다.
- 삭제 버튼을 공통 아이콘으로 교체

## 🌱 구현 내용

- [x] 칸반보드 x scroll snap 적용
- [x] clipboard가 없는 환경인 경우 document.execCommand('copy')로 복사하도록 대응
- [x] axios 에러 처리 구문 switch에서 if문으로 변경
- [x] 삭제 버튼을 공통으로 사용하는 아이콘으로 교체

## ✅ check list

- 이슈 내용을 전부 적용했나요?
- 산정한 작업 기간 내에 개발했나요?
