### PR TITLE
[FIX][FEAT] 체크 상태가 반영 되지 않는 이슈 및 Textarea 높이 이슈 수정, focus scroll 기능 추가

### DIFF
--- a/src/components/Requirement/RequirementCheckToggle.tsx
+++ b/src/components/Requirement/RequirementCheckToggle.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { useRequirement } from '@/hooks/useRequirement';
 import { RequirementStateType } from '@/types/requirement';
@@ -13,17 +13,20 @@ type RequirementCheckToggle = {
 };
 
 export default function RequirementCheckToggle({ requirement }: RequirementCheckToggle) {
-  const { isCompleted } = requirement;
   const { updateRequire } = useRequirement();
 
   const [isClicked, setIsClicked] = useState(false);
-  const [isChecked, setIsChecked] = useState(isCompleted);
+  const [isChecked, setIsChecked] = useState(false);
 
   const handleToggleChecked = () => {
     !isClicked && setIsClicked(true);
     setIsChecked(!isChecked);
     updateRequire({ ...requirement, isCompleted: !isChecked });
   };
+
+  useEffect(() => {
+    setIsChecked(requirement.isCompleted);
+  }, [requirement]);
 
   return (
     <div css={requirementCheckToggle} onClick={handleToggleChecked}>

--- a/src/components/common/Textarea.tsx
+++ b/src/components/common/Textarea.tsx
@@ -1,6 +1,6 @@
 import { ForwardedRef, forwardRef, useEffect } from 'react';
 
-import { autoResizeTextarea, blurTextarea } from '@/utils/textarea';
+import { autoResizeTextarea, blurTextarea, scrollToTextarea } from '@/utils/textarea';
 
 interface TextareaProps extends React.ComponentProps<'textarea'> {
   value: string;
@@ -16,6 +16,10 @@ const Textarea = (
 ) => {
   const title = value.trim();
 
+  const handleFocus = () => {
+    scrollToTextarea(ref);
+  };
+
   const handleBlur = () => {
     if (title !== '') {
       onUpdate(title);
@@ -30,6 +34,10 @@ const Textarea = (
       blurTextarea(ref);
     } else {
       autoResizeTextarea(ref);
+
+      setTimeout(() => {
+        scrollToTextarea(ref);
+      }, 200);
     }
   };
 
@@ -54,6 +62,7 @@ const Textarea = (
       ref={ref}
       value={value}
       autoFocus={autoFocus}
+      onFocus={handleFocus}
       onBlur={handleBlur}
       onKeyDown={handleKeyDown}
       spellCheck={false}

--- a/src/components/common/Textarea.tsx
+++ b/src/components/common/Textarea.tsx
@@ -25,8 +25,11 @@ const Textarea = (
 
   const handleSubmit = () => {
     onSubmit();
+
     if (!autoFocus) {
       blurTextarea(ref);
+    } else {
+      autoResizeTextarea(ref);
     }
   };
 

--- a/src/utils/textarea.ts
+++ b/src/utils/textarea.ts
@@ -21,3 +21,12 @@ export function autoResizeTextarea(ref: ForwardedRef<HTMLTextAreaElement>) {
     }
   }
 }
+
+export function scrollToTextarea(ref: ForwardedRef<HTMLTextAreaElement>) {
+  if (ref !== null && typeof ref !== 'function') {
+    const current = ref.current;
+    if (current) {
+      current.scrollIntoView({ block: 'center', behavior: 'smooth' });
+    }
+  }
+}


### PR DESCRIPTION
## 🌱 만들고자 하는 기능

- 모달 내에서 isCompleted 상태를 변경하고 모달을 닫았을 때, 칸반보드에서는 반영이 안 되는 이슈를 해결합니다.
- 입력에서 개행을 하고 submit을 했을 때 textarea의 높이가 초기화 되지 않는 문제를 수정합니다.
- textarea가 focus 되면 화면의 가운데로 scroll 하는 기능을 추가합니다.

## 🌱 구현 내용

- [x] Toggle을 담당하는 컴포넌트의 isCompleted 상태를 요구사항이 변경될 때마다 변경하도록 수정합니다.
- [x] 입력 textarea의 경우 submit 후에 높이 초기화 하기
- [x] textarea focus scroll 기능 추가 

## ✅ check list

- 이슈 내용을 전부 적용했나요?
- 산정한 작업 기간 내에 개발했나요?
