### PR TITLE
[FEAT] ErrorBoundary 적용

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "react": "^18.2.0",
     "react-beautiful-dnd": "^13.1.1",
     "react-dom": "^18.2.0",
+    "react-error-boundary": "^4.0.11",
     "react-icons": "^4.10.1",
     "react-loader-spinner": "^5.3.4",
     "react-query": "^3.39.3",

--- a/src/components/common/ErrorFallback.tsx
+++ b/src/components/common/ErrorFallback.tsx
@@ -1,0 +1,38 @@
+import { css } from '@emotion/react';
+import { useErrorBoundary } from 'react-error-boundary';
+
+import { theme, ThemeType } from '@/styles/theme';
+
+export default function ErrorFallback() {
+  const { resetBoundary } = useErrorBoundary();
+
+  return (
+    <div css={errorFallbackStyle(theme)}>
+      <p>문제가 발생했습니다.</p>
+      <button onClick={resetBoundary}>새로고침</button>
+    </div>
+  );
+}
+
+const errorFallbackStyle = (theme: ThemeType) => css`
+  height: calc(100vh - 56px);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 12px;
+  padding-bottom: 56px;
+  color: ${theme.colors.primary};
+
+  p {
+    font-size: 1.2rem;
+    font-weight: 500;
+  }
+
+  button {
+    border: 1px solid ${theme.colors.primary};
+    color: ${theme.colors.green};
+    border-radius: 8px;
+    padding: 4px;
+  }
+`;

--- a/src/pages/_layout.tsx
+++ b/src/pages/_layout.tsx
@@ -1,6 +1,8 @@
 import { Suspense, useState } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
 import { Outlet } from 'react-router-dom';
 
+import ErrorFallback from '@/components/common/ErrorFallback';
 import Header from '@/components/common/Header';
 import Loading from '@/components/common/Loading';
 import Navbar from '@/components/common/Navbar';
@@ -19,9 +21,11 @@ export default function Layout() {
       <Header onToggleNav={toggleNav} />
       <Navbar isNavOpen={isNavOpen} setIsNavOpen={setIsNavOpen} />
 
-      <Suspense fallback={<Loading />}>
-        <Outlet />
-      </Suspense>
+      <ErrorBoundary FallbackComponent={ErrorFallback}>
+        <Suspense fallback={<Loading />}>
+          <Outlet />
+        </Suspense>
+      </ErrorBoundary>
 
       <ModalContainer />
       <ToastContainer />

--- a/yarn.lock
+++ b/yarn.lock
@@ -2793,6 +2793,13 @@ react-dom@^18.2.0:
     loose-envify "^1.1.0"
     scheduler "^0.23.0"
 
+react-error-boundary@^4.0.11:
+  version "4.0.11"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-4.0.11.tgz#36bf44de7746714725a814630282fee83a7c9a1c"
+  integrity sha512-U13ul67aP5DOSPNSCWQ/eO0AQEYzEFkVljULQIjMV0KlffTAhxuDoBKdO0pb/JZ8mDhMKFZ9NZi0BmLGUiNphw==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+
 react-icons@^4.10.1:
   version "4.10.1"
   resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-4.10.1.tgz#3f3b5eec1f63c1796f6a26174a1091ca6437a500"


### PR DESCRIPTION
## 🌱 만들고자 하는 기능

- 에러 상황을 핸들하기 위해, 에러로 인해 전체 웹이 다운되는 것을 막기 위해 ErrorBoundary를 적용합니다.
- react-error-boundary를 사용하여 ErrorBoundary를 적용합니다.
- 버튼을 클릭하면 error 상황에서 벗어날 수 있도록 reset 함수를 등록합니다.

## 🌱 구현 내용

- [x] react-error-boundary 설치
- [x] ErrorBoundary 및 Fallback component 적용
- [x] Fallback component 버튼에 reset 함수 등록

## ✅ check list

- 이슈 내용을 전부 적용했나요?
- 산정한 작업 기간 내에 개발했나요?
