### PR TITLE
[FIX] 사파리 15 버전에서 safe-area가 적용되지 않는 이슈 해결

### DIFF
--- a/src/components/common/Navbar.tsx
+++ b/src/components/common/Navbar.tsx
@@ -63,7 +63,7 @@ export default function Navbar({ isNavOpen, setIsNavOpen }: NavbarProps) {
 
 const navBarStyle = (isNavOpen: boolean) => css`
   width: 100%;
-  height: 100vh;
+  height: 100%;
   position: absolute;
   top: 0;
   left: env(safe-area-inset-left);
@@ -72,7 +72,8 @@ const navBarStyle = (isNavOpen: boolean) => css`
 
   .nav-overlay {
     width: 100%;
-    height: 100vh;
+    height: 100%;
+    position: absolute;
     opacity: ${isNavOpen ? 1 : 0};
     background: #00000090;
     transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;

--- a/src/styles/reset.ts
+++ b/src/styles/reset.ts
@@ -14,7 +14,7 @@ export const reset = css`
   body {
     width: 100%;
     min-height: 100vh;
-    min-height: calc(100vh - env(safe-area-inset-top) - env(safe-area-inset-bottom));
+    min-height: -webkit-fill-available;
 
     padding: constant(safe-area-inset-top) constant(safe-area-inset-right)
       constant(safe-area-inset-bottom) constant(safe-area-inset-left);


### PR DESCRIPTION
## 🌱 만들고자 하는 기능

- 100vh에서 safe-area의 값을 빼서 화면을 꽉 채우려고 하였으나, 사파리 15 버전에서는 동작하지 않는 것을 확인했습니다.
- 따라서 min-height 속성을 '-webkit-fill-available'으로 교체합니다.
- 모바일 화면에서 노치, 인디케이터 영역을 제외한 영역을 높이로 가지도록 설정합니다.

## 🌱 구현 내용

- [x] body의 min-height을 '-webkit-fill-available'으로 교체
- [x] navbar의 height를 100vh에서 100%으로 수정

## ✅ check list

- 이슈 내용을 전부 적용했나요?
- 산정한 작업 기간 내에 개발했나요?
